### PR TITLE
Switch to docker-compose CLI and remove custom network

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,9 +52,9 @@ jobs:
             # Navigate to the application directory
             cd /home/api
             # Stop existing containers and remove orphaned containers
-            docker compose down --remove-orphans
+            docker-compose down --remove-orphans
             # Start the application in detached mode
-            docker compose up --no-build -d
+            docker-compose up --no-build -d
           EOF
 
       # Clean up build artifacts locally

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,18 +7,3 @@ services:
     ports:
       - "3000:3000"
     restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - PORT=3000
-    healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/check', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-    networks:
-      - huay-network
-
-networks:
-  huay-network:
-    driver: bridge


### PR DESCRIPTION
Replaced 'docker compose' with 'docker-compose' in CI/CD workflow for compatibility. Removed environment variables, healthcheck, and custom network configuration from docker-compose.yml, simplifying the service setup.