### PR TITLE
Add MongoDB service to docker-compose and update CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,11 +18,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build the Docker image with specified tag
-      - name: Build Docker image
-        run: |
-          docker build -t huay_backend:1.0.0 .
-
       # Deploy the application on the remote server
       - name: Deploy to server
         env:
@@ -38,7 +33,7 @@ jobs:
             git reset --hard origin/prod
             # Stop existing containers
             docker-compose down
-            # Build and start containers
+            # Build and start containers (build on server)
             docker-compose up -d --build
             # Wait for containers to start
             sleep 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,34 @@
 version: '3.8'
 
 services:
+  mongodb:
+    image: mongo:7.0
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=admin123
+      - MONGO_INITDB_DATABASE=huay-backend
+    volumes:
+      - mongodb_data:/data/db
+    restart: unless-stopped
+
   huay-backend:
     image: huay_backend:1.0.0
     container_name: huay-backend
     ports:
       - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - MONGO_URI=mongodb://huayuser:huaypass123@mongodb:27017/huay-backend
+    depends_on:
+      - mongodb
     restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+volumes:
+  mongodb_data:


### PR DESCRIPTION
Introduces a MongoDB service to docker-compose.yml with persistent storage and environment variables. Updates the huay-backend service to depend on MongoDB and use build context. Removes Docker image build step from GitHub Actions workflow, shifting build responsibility to the server during deployment.